### PR TITLE
Getting the websocket to work in embedded servlet con…

### DIFF
--- a/src/main/java/org/nextrtc/examples/videochat_with_rest/config/NextRTCEndpointConfig.java
+++ b/src/main/java/org/nextrtc/examples/videochat_with_rest/config/NextRTCEndpointConfig.java
@@ -2,10 +2,23 @@ package org.nextrtc.examples.videochat_with_rest.config;
 
 import org.nextrtc.signalingserver.NextRTCConfig;
 import org.springframework.context.annotation.Configuration;
+import org.nextrtc.examples.videochat_with_rest.MyEndpoint;
 import org.springframework.context.annotation.Import;
+import org.springframework.web.socket.server.standard.ServerEndpointExporter;
+import org.springframework.context.annotation.Bean;
 
 @Configuration
 @Import(NextRTCConfig.class)
 public class NextRTCEndpointConfig {
 
+    @Bean
+    public MyEndpoint myEndpoint() {
+        return new MyEndpoint();
+    }
+
+
+    @Bean
+    public ServerEndpointExporter serverEndpointExporter() {
+        return new ServerEndpointExporter();
+    }
 }

--- a/src/main/webapp/conversation.html
+++ b/src/main/webapp/conversation.html
@@ -36,7 +36,7 @@
 		var nextRTC = null;
 		NextRTC.onReady = function() {
 			nextRTC = new NextRTC({
-				wsURL : 'ws://localhost:9080/signaling',
+				wsURL : 'ws://localhost:8080/signaling',
 				mediaConfig : {
 					video : true,
 					audio : true,


### PR DESCRIPTION
It turns out that the @ServerEndpoint requires some extra beans for use in an embedded servlet container. The changes shouldn't impact deploying a war to a stand alone server but I didn't test it. I also changed the JS to connect to the websocket on port 8080 instead of 9080 since 8080 is the default Spring Boot startup port.
