### PR TITLE
Alternate registration in case mail isn't configured

### DIFF
--- a/src/main/java/org/nextrtc/examples/videochat_with_rest/controller/RegisterController.java
+++ b/src/main/java/org/nextrtc/examples/videochat_with_rest/controller/RegisterController.java
@@ -3,6 +3,7 @@ package org.nextrtc.examples.videochat_with_rest.controller;
 import org.nextrtc.examples.videochat_with_rest.service.RegisterUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -15,10 +16,13 @@ public class RegisterController {
     private RegisterUserService service;
 
     @RequestMapping(value = "register", method = RequestMethod.POST)
-    public String registerUser(@ModelAttribute("username") String username, @ModelAttribute("password") String password, @ModelAttribute("email") String email) {
+    public String registerUser(@ModelAttribute("username") String username, @ModelAttribute("password") String password, @ModelAttribute("email") String email, Model model) {
 
-        service.register(username, password, email);
-
+    	String confirmationKey = service.generateConfirmationKey();
+        service.register(username, password, email, confirmationKey);
+        
+        model.addAttribute("key", confirmationKey);
+        
         return "login";
     }
 }

--- a/src/main/java/org/nextrtc/examples/videochat_with_rest/controller/VerificationController.java
+++ b/src/main/java/org/nextrtc/examples/videochat_with_rest/controller/VerificationController.java
@@ -3,6 +3,7 @@ package org.nextrtc.examples.videochat_with_rest.controller;
 import org.nextrtc.examples.videochat_with_rest.service.VerifyUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -15,10 +16,11 @@ public class VerificationController {
     private VerifyUserService service;
 
     @RequestMapping(value = "verify/{key}", method = RequestMethod.GET)
-    public String verify(@PathVariable String key) {
+    public String verify(@PathVariable String key, Model model) {
 
         service.verify(key);
-
+        
+        model.addAttribute("key", null);
         return "login";
     }
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -7,6 +7,13 @@
 <div th:if="${param.error}">
     Invalid username and password.
 </div>
+
+<span th:text="${test}"></span>
+
+<div th:if="${key}">
+	A registration confirmation email has been set but you can use "/action/verify/<span th:text="${key}"></span>" as a shortcut 
+</div>
+
 <div th:if="${param.logout}">
     You have been logged out.
 </div>


### PR DESCRIPTION
Puts the confirmation key and path on the screen after the registration process. When a user uses the embedded container mail isn't going to work out of the box.
